### PR TITLE
Avoid "Missing serialize REPR function for REPR VMException (BOOTExce…

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -3,7 +3,7 @@
     "Timo Paulssen"
   ],
   "build-depends" : [ ],
-  "depends" : [ "JSON::Fast", "MoarVM::Remote" ],
+  "depends" : [ "JSON::Fast", "MoarVM::Remote", "Terminal::ANSIColor" ],
   "description" : "A command line interface application for debugging Perl 6 and NQP code using the MoarVM remote debugger.",
   "license" : "Artistic-2.0",
   "name" : "App::MoarVM::Debug",

--- a/lib/App/MoarVM/Debug/Formatter.pm6
+++ b/lib/App/MoarVM/Debug/Formatter.pm6
@@ -1,6 +1,7 @@
 unit module MoarVM::Remote::CLI::Formatter;
 
-my $has-color = (try require Terminal::ANSIColor) !=== Nil;
+my $has-color = True;
+require Terminal::ANSIColor;
 my $wants-color = $*OUT.t;
 
 our sub wants-color is rw is export {


### PR DESCRIPTION
…ption)"

``` (try require Terminal::ANSIColor) !=== Nil ```
results in ```Missing serialize REPR function for REPR VMException (BOOTException)``` , dont know howto fix it otherwise.